### PR TITLE
separated API requets

### DIFF
--- a/src/utils/fetchCallCardData.js
+++ b/src/utils/fetchCallCardData.js
@@ -43,4 +43,4 @@ const fetchCallCardData = async (selectedClasses, start, end, selectedCompanies)
   }
 }
 
-export default handleFetch;
+export default fetchCallCardData;


### PR DESCRIPTION
Moved API requests for companies, callCardData and chartData out into different functions in separate effects.  Companies should now only ever run once on the first render, chartData should only run when the charts are viewed.  This speeds up loading time for the default calls view.